### PR TITLE
feat(plugins): Allow waitForCondition/Promise with ignoreSynchronization

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -70,7 +70,7 @@ currently pending tasks on the WebDriver control flow.
 -- WebDriver control flow schedule
  |- waiting for debugger to attach
  |---    at [object Object].<anonymous> (failure_spec.js:13:13)
- |- Protractor.waitForAngular()
+ |- Protractor.waitForStableStatus()
  |---    at [object Object].<anonymous> (failure_spec.js:16:59)
 wd-debug>
 ```
@@ -191,8 +191,8 @@ matching a locator.
 
 Element explorer will start chrome by default. However, you can specify
 another browser, change browser settings, or specify any other config that you
-normally would with your protractor test. To do this, pass configs to 
-protractor like you normally would, 
+normally would with your protractor test. To do this, pass configs to
+protractor like you normally would,
 but with the `--elementExplorer` flag set:
 
     protractor [configFile] [options] --elementExplorer
@@ -201,11 +201,11 @@ For example, to connect to ChromeDriver directly, use
 
     protractor --directConnect --elementExplorer
 
-Element explore will ignore your specs, not set up your framework (e.g. jasmine, 
+Element explore will ignore your specs, not set up your framework (e.g. jasmine,
 mocha, cucumber), and only allow you to pass in 1 capability, but will honor
 every other parameter in your config.
 
-Note `baseUrl` is used here as the initial page, i.e. element explorer will try 
+Note `baseUrl` is used here as the initial page, i.e. element explorer will try
 to navigate to `baseUrl` automatically on start.
 
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -168,7 +168,7 @@ exports.rewriteURL = function() {};
 
 /**
  * This is called inside browser.get() directly after the page loads, and before
- * angular has had time to bootstrap/synchronize. 
+ * angular has had time to bootstrap/synchronize.
  *
  * @this {Object} bound to module.exports
  *
@@ -198,10 +198,10 @@ exports.onPageLoad = function() {};
 exports.onPageStable = function() {};
 
 /**
- * Between every webdriver action, Protractor calls browser.waitForAngular() to
+ * Between every webdriver action, Protractor calls browser.waitForStableStatus() to
  * make sure that Angular has no outstanding $http or $timeout calls.
  * You can use waitForPromise() to have Protractor additionally wait for your
- * custom promise to be resolved inside of browser.waitForAngular().
+ * custom promise to be resolved inside of browser.waitForStableStatus().
  *
  * @this {Object} bound to module.exports
  *
@@ -218,7 +218,7 @@ exports.onPageStable = function() {};
 exports.waitForPromise = function() {};
 
 /**
- * Between every webdriver action, Protractor calls browser.waitForAngular() to
+ * Between every webdriver action, Protractor calls browser.waitForStableStatus() to
  * make sure that Angular has no outstanding $http or $timeout calls.
  * You can use waitForCondition() to have Protractor additionally wait for your
  * custom condition to be truthy.

--- a/lib/element.js
+++ b/lib/element.js
@@ -131,7 +131,7 @@ ElementArrayFinder.prototype.all = function(locator) {
   var getWebElements = function() {
     if (self.getWebElements === null) {
       // This is the first time we are looking for an element
-      return ptor.waitForAngular().then(function() {
+      return ptor.waitForStableStatus().then(function() {
         if (locator.findElementsOverride) {
           return locator.findElementsOverride(ptor.driver, null, ptor.rootEl);
         } else {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -80,7 +80,7 @@ function annotatePluginObj(self, obj, conf, i) {
         'from "' + obj.name + '" plugin') +
         ': ' + message);
   };
-};
+}
 
 function printPluginResults(specResults) {
   var green = '\x1b[32m';

--- a/lib/protractor.js
+++ b/lib/protractor.js
@@ -103,7 +103,7 @@ var Protractor = function(webdriverInstance, opt_baseUrl, opt_rootElement) {
   for (var method in webdriverInstance) {
     if (!this[method] && typeof webdriverInstance[method] == 'function') {
       if (methodsToSync.indexOf(method) !== -1) {
-        mixin(this, webdriverInstance, method, this.waitForAngular.bind(this));
+        mixin(this, webdriverInstance, method, this.waitForStableStatus.bind(this));
       } else {
         mixin(this, webdriverInstance, method);
       }
@@ -265,8 +265,8 @@ Protractor.prototype.executeAsyncScript_ =
     };
 
 /**
- * Instruct webdriver to wait until Angular has finished rendering and has
- * no outstanding $http or $timeout calls before continuing.
+ * Instruct webdriver to wait until browser and plugins status is stable
+ * including a waitForAngular.
  * Note that Protractor automatically applies this command before every
  * WebDriver action.
  *
@@ -275,33 +275,13 @@ Protractor.prototype.executeAsyncScript_ =
  * @return {!webdriver.promise.Promise} A promise that will resolve to the
  *    scripts return value.
  */
-Protractor.prototype.waitForAngular = function(opt_description) {
-  var description = opt_description ? ' - ' + opt_description : '';
+Protractor.prototype.waitForStableStatus = function(opt_description) {
   var self = this;
-  if (this.ignoreSynchronization) {
-    return webdriver.promise.fulfilled();
-  }
-
-  return this.executeAsyncScript_(
-      clientSideScripts.waitForAngular,
-      'Protractor.waitForAngular()' + description,
-      this.rootEl).
-      then(function(browserErr) {
-        if (browserErr) {
-          throw 'Error while waiting for Protractor to ' +
-                'sync with the page: ' + JSON.stringify(browserErr);
-        }
-    }).then(function() {
-      return self.driver.controlFlow().execute(function() {
-        return self.plugins_.waitForPromise();
-      }, 'Plugins.waitForPromise()').then(function() {
-        return self.driver.wait(function() {
-          return self.plugins_.waitForCondition().then(function(results) {
-            return results.reduce(function(x, y) { return x && y; }, true);
-          });
-        }, undefined, 'Plugins.waitForCondition()');
-      });
-    }, function(err) {
+  return this.waitForAngular(opt_description)
+    .then(function () {
+      return self.waitForPlugins();
+    })
+    .then(null, function(err) {
       var timeout;
       if (/asynchronous script timeout/.test(err.message)) {
         // Timeout on Chrome
@@ -322,7 +302,7 @@ Protractor.prototype.waitForAngular = function(opt_description) {
           'Protractor.waitForAngular() - getting pending timeouts' + description
         );
         var pendingHttpsPromise = self.executeScript_(
-          clientSideScripts.getPendingHttpRequests, 
+          clientSideScripts.getPendingHttpRequests,
           'Protractor.waitForAngular() - getting pending https' + description,
           self.rootEl
         );
@@ -352,6 +332,52 @@ Protractor.prototype.waitForAngular = function(opt_description) {
       } else {
         throw err;
       }
+    });
+};
+
+/**
+ * Instruct webdriver to wait until Plugins has finished.
+
+ * @return {!webdriver.promise.Promise} A promise that will resolve to the
+ *    scripts return value.
+ */
+Protractor.prototype.waitForPlugins = function() {
+  var self = this;
+  return this.driver.controlFlow().execute(function() {
+    return self.plugins_.waitForPromise();
+  }, 'Plugins.waitForPromise()').then(function() {
+    return self.driver.wait(function() {
+      return self.plugins_.waitForCondition().then(function(results) {
+        return results.reduce(function(x, y) { return x && y; }, true);
+      });
+    }, undefined, 'Plugins.waitForCondition()');
+  });
+};
+
+/**
+ * Instruct webdriver to wait until Angular has finished rendering and has
+ * no outstanding $http or $timeout calls before continuing.
+ *
+ * @param {string=} opt_description An optional description to be added
+ *     to webdriver logs.
+ * @return {!webdriver.promise.Promise} A promise that will resolve to the
+ *    scripts return value.
+ */
+Protractor.prototype.waitForAngular = function(opt_description) {
+  var description = opt_description ? ' - ' + opt_description : '';
+  if (this.ignoreSynchronization) {
+    return webdriver.promise.fulfilled();
+  }
+
+  return this.executeAsyncScript_(
+      clientSideScripts.waitForAngular,
+      'Protractor.waitForAngular()' + description,
+      this.rootEl).
+      then(function(browserErr) {
+        if (browserErr) {
+          throw 'Error while waiting for Protractor to ' +
+                'sync with the page: ' + JSON.stringify(browserErr);
+        }
     });
 };
 
@@ -468,7 +494,7 @@ Protractor.prototype.addBaseMockModules_ = function() {
             if (!window.NG_PENDING_TIMEOUTS) {
               window.NG_PENDING_TIMEOUTS = {};
             }
-              
+
             var extendedTimeout = function() {
               var args = Array.prototype.slice.call(arguments);
               if (typeof(args[0]) !== 'function') {
@@ -480,12 +506,12 @@ Protractor.prototype.addBaseMockModules_ = function() {
               window.NG_PENDING_TIMEOUTS[taskId] = fn.toString();
               var wrappedFn = (function(taskId_) {
                 return function() {
-                  delete window.NG_PENDING_TIMEOUTS[taskId_]; 
+                  delete window.NG_PENDING_TIMEOUTS[taskId_];
                   return fn.apply(null, arguments);
                 };
               })(taskId);
               args[0] = wrappedFn;
-              
+
               var promise = $timeout.apply(null, args);
               promise.ptorTaskId_ = taskId;
               return promise;
@@ -494,11 +520,11 @@ Protractor.prototype.addBaseMockModules_ = function() {
             extendedTimeout.cancel = function() {
               var taskId_ = arguments[0] && arguments[0].ptorTaskId_;
               if (taskId_) {
-                delete window.NG_PENDING_TIMEOUTS[taskId_]; 
+                delete window.NG_PENDING_TIMEOUTS[taskId_];
               }
               return $timeout.cancel.apply($timeout, arguments);
             };
-             
+
             return extendedTimeout;
           }]);
         }]);
@@ -678,7 +704,7 @@ Protractor.prototype.navigate = function() {
  *    page has been changed.
  */
 Protractor.prototype.setLocation = function(url) {
-  this.waitForAngular();
+  this.waitForStableStatus();
   return this.executeScript_(clientSideScripts.setLocation,
     'Protractor.setLocation()', this.rootEl, url).then(function(browserErr) {
       if (browserErr) {
@@ -697,7 +723,7 @@ Protractor.prototype.setLocation = function(url) {
  *     .toBe('http://angular.github.io/protractor/#/api');
  */
 Protractor.prototype.getLocationAbsUrl = function() {
-  this.waitForAngular();
+  this.waitForStableStatus();
   return this.executeScript_(clientSideScripts.getLocationAbsUrl,
       'Protractor.getLocationAbsUrl()', this.rootEl);
 };
@@ -758,7 +784,7 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
   var onPortAvailable = function(port, fn) {
     var net = require('net');
     var tester = net.connect({port: port}, function() {
-      console.error('Port ' + port + ' is already in use. Please specify ' + 
+      console.error('Port ' + port + ' is already in use. Please specify ' +
         'another port to debug.');
       process.exit(1);
     });
@@ -766,7 +792,7 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
       if (err.code === 'ECONNREFUSED') {
         tester.once('close', fn).end();
       } else {
-        console.error('Unexpected failure testing for port ' + port + ': ', 
+        console.error('Unexpected failure testing for port ' + port + ': ',
           err);
         process.exit(1);
       }
@@ -795,7 +821,7 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
   var sandbox = vm_.createContext(context);
 
   var browserUnderDebug = this;
-  flow.execute(function() {    
+  flow.execute(function() {
     log.puts('Starting WebDriver debugger in a child process. Pause is ' +
         'still beta, please report issues at github.com/angular/protractor\n');
     process.debugPort = opt_debugPort || process.debugPort;
@@ -807,10 +833,10 @@ Protractor.prototype.initDebugger_ = function(debuggerClientPath, opt_debugPort)
       var nodedebug = require('child_process').fork(debuggerClientPath, args);
       process.on('exit', function() {
         nodedebug.kill('SIGTERM');
-      }); 
+      });
     });
   });
-  
+
   var pausePromise = flow.timeout(1000, 'waiting for debugger to attach')
       .then(function() {
         // Necessary for backward compatibility with node < 0.12.0

--- a/spec/plugins/specs/browser_get_wait_spec.js
+++ b/spec/plugins/specs/browser_get_wait_spec.js
@@ -1,6 +1,6 @@
 describe('category', function() {
   it('name', function() {
     browser.get('index.html');
-    browser.waitForAngular();
+    browser.waitForStableStatus();
   });
 });

--- a/website/test/e2e/api_spec.js
+++ b/website/test/e2e/api_spec.js
@@ -73,7 +73,7 @@ describe('Api', function() {
     expect(apiPage.title.getText()).toBe('element(locator) View code');
     expect(browser.getCurrentUrl()).toMatch(/api\?view=ElementFinder/);
   });
-  
+
   it('should show child functions', function() {
     // Given that you go to element.all().
     apiPage.clickOnMenuItem('element.all(locator)');
@@ -114,7 +114,7 @@ describe('Api', function() {
 
     // Then ensure the child functions are shown.
     expect(apiPage.getChildFunctionNames()).toEqual([
-      'waitForAngular', 'findElement', 'findElements', 'isElementPresent',
+      'waitForAngular', 'waitForStableStatus', 'findElement', 'findElements', 'isElementPresent',
       'addMockModule', 'clearMockModules', 'removeMockModule',
       'getRegisteredMockModules', 'get', 'refresh', 'navigate', 'setLocation',
       'getLocationAbsUrl', 'debugger', 'enterRepl', 'pause']);


### PR DESCRIPTION
I've been trying to use the new plugin-api to solve https://github.com/angular/protractor/issues/2246 and it turns out waitForCondition/Promise are not executed when you're not in angular application (as ignoreSynchronization is needed).

This PR aims to address this by always running waitFor\* on plugins, providing a new waitForStableStatus method.
